### PR TITLE
Implemented way to sort tracked DB changes by a config specified column, instead of primary key column

### DIFF
--- a/Streams.ChangeTracking/Config/ChangeTrackingConfiguration.cs
+++ b/Streams.ChangeTracking/Config/ChangeTrackingConfiguration.cs
@@ -26,11 +26,16 @@ namespace Com.Rfranco.Streams.ChangeTracking.Config
         public long PollIntervalMilliseconds { get; set; }
 
         /// <summary>
+        /// Enable/Disable a custom sort based on specific column of each table
+        /// </summary>
+        /// <value>bool to enable or disable the custom sort</value>
+        public bool CustomSortEnable { get; set; } = false;
+
+        /// <summary>
         /// IEnumerable with information related to the tables configured with change tracking
         /// </summary>
         /// <value>ChangeTrackingTableConfiguration instance white table configured</value>
         public IEnumerable<ChangeTrackingTableConfiguration> WhiteListTables { get; set; }
-        
     }
 
     /// <summary>
@@ -56,5 +61,10 @@ namespace Com.Rfranco.Streams.ChangeTracking.Config
         /// <value>Priority (high value to lower value)</value>
         public int Priority { get; set; } = 1;
 
+        /// <summary>
+        /// Column of the track table to sort results by
+        /// </summary>
+        /// <value>Column to sort by</value>
+        public string SortColumn { get; set; }
     }
 }

--- a/Streams.ChangeTracking/Repository/ChangeTrackingRepository.cs
+++ b/Streams.ChangeTracking/Repository/ChangeTrackingRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
@@ -21,23 +22,23 @@ namespace Com.Rfranco.Streams.ChangeTracking.Repositories
 
         IEnumerable<TrackedTableInformation> GetTrackedTablesInformation(IDbConnection conn);
 
-        IEnumerable<Change> GetOffsetChanges(IDbConnection conn, TrackedTableInformation changeTrackingTableInfo, 
-            long changeVersionFrom, long changeVersionTo);
+        IEnumerable<Change> GetOffsetChanges(IDbConnection conn, 
+            TrackedTableInformation changeTrackingTableInfo, long changeVersionFrom, long changeVersionTo);
     }
 
     public class ChangeTrackingRepository : IChangeTrackingRepository
     {
-        private ChangeTrackingConfiguration Configuration;
+        private readonly ChangeTrackingConfiguration configuration;
 
 
         public ChangeTrackingRepository(ChangeTrackingConfiguration configuration)
         {
-            Configuration = configuration;
+            this.configuration = configuration;
         }
 
         public IDbConnection CreateConnection()
         {
-            SqlConnection connection = new SqlConnection(Configuration.ConnectionString);
+            SqlConnection connection = new SqlConnection(configuration.ConnectionString);
             if (connection.State != ConnectionState.Open)
                 connection.Open();
             return connection;
@@ -67,13 +68,14 @@ namespace Com.Rfranco.Streams.ChangeTracking.Repositories
         {
             List<TrackedTableInformation> tableInformations = new List<TrackedTableInformation>();
 
-            foreach (var whiteListTableConfiguration in Configuration.WhiteListTables)
+            foreach (var whiteListTableConfiguration in configuration.WhiteListTables)
             {
                 var tableInformation = conn.Query<TrackedTableInformation>(
                   $"SELECT OBJECT_SCHEMA_NAME(object_id) AS SchemaName,"
                 + "Object_Name(object_id) AS TableName,"
-                + "min_valid_version AS MinValidVersion,"
+                + "min_valid_version AS MinValidVersion, "
                 + $"'{whiteListTableConfiguration.PrimaryKeyColumn}' AS PrimaryKeyColumn "
+                + (configuration.CustomSortEnable ? $",'{whiteListTableConfiguration.SortColumn}' AS SortColumn " : "")
                 + $" FROM sys.change_tracking_tables WHERE CONCAT(OBJECT_SCHEMA_NAME(object_id),'.', Object_Name(object_id)) = @TableName",
                     new
                     {
@@ -90,24 +92,48 @@ namespace Com.Rfranco.Streams.ChangeTracking.Repositories
         }
 
         /// <summary>
-        /// Gete changes since offset
+        /// Get changes between provied change versions
         /// </summary>
         /// <param name="conn">Database connection</param>
         /// <param name="changeTrackingTableInfo">Tracked table information</param>
-        /// <param name="offset">Current offset</param>
-        /// <returns>Changes since offset provided</returns>
-        public IEnumerable<Change> GetOffsetChanges(IDbConnection conn, TrackedTableInformation changeTrackingTableInfo, 
+        /// <param name="changeVersionFrom">Changes version from</param>
+        /// <param name="changeVersionTo">Changes version to</param>
+        /// <returns>Detected changes between specified change versions</returns>
+        public IEnumerable<Change> GetOffsetChanges(IDbConnection conn, 
+            TrackedTableInformation changeTrackingTableInfo, long changeVersionFrom, long changeVersionTo)
+        {
+            if(configuration.CustomSortEnable && string.IsNullOrEmpty(changeTrackingTableInfo.SortColumn))
+                throw new ArgumentException("Sort column of tracked table should be specified if custom sort is enable.");
+
+            var query = configuration.CustomSortEnable ? 
+                LoadChangesWithCustomSortColumnQuery(changeTrackingTableInfo, changeVersionFrom, changeVersionTo) :
+                LoadChangesSortByPrimaryKeyQuery(changeTrackingTableInfo, changeVersionFrom, changeVersionTo);
+            
+            return conn.Query<Change>(query).Distinct();
+        }
+        private string LoadChangesSortByPrimaryKeyQuery(TrackedTableInformation changeTrackingTableInfo, 
             long changeVersionFrom, long changeVersionTo)
         {
-            return conn.Query<Change>(
-                $"SELECT CT.{changeTrackingTableInfo.PrimaryKeyColumn} AS PrimaryKeyValue, "
+            return $"SELECT CT.{changeTrackingTableInfo.PrimaryKeyColumn} AS PrimaryKeyValue, "
                 + $"'{changeTrackingTableInfo.GetFullTableName()}' AS TableFullName, "
                 + "SYS_CHANGE_OPERATION AS _ChangeOperation, "
                 + "SYS_CHANGE_VERSION AS ChangeVersion "
-                + $"FROM  CHANGETABLE(CHANGES {changeTrackingTableInfo.GetFullTableName()} , {changeVersionFrom}) AS CT "
+                + $"FROM CHANGETABLE(CHANGES {changeTrackingTableInfo.GetFullTableName()} , {changeVersionFrom}) AS CT "
                 + $"WHERE SYS_CHANGE_VERSION <= {changeVersionTo} "
-                + $"Order by CT.{changeTrackingTableInfo.PrimaryKeyColumn} ASC")
-                .Distinct();
+                + $"Order by CT.{changeTrackingTableInfo.PrimaryKeyColumn} DESC";
+        }
+        private string LoadChangesWithCustomSortColumnQuery(TrackedTableInformation changeTrackingTableInfo, 
+            long changeVersionFrom, long changeVersionTo)
+        {
+            return $"SELECT CT.{changeTrackingTableInfo.PrimaryKeyColumn} AS PrimaryKeyValue, "
+                + $"'{changeTrackingTableInfo.GetFullTableName()}' AS TableFullName, "
+                + "SYS_CHANGE_OPERATION AS _ChangeOperation, "
+                + "SYS_CHANGE_VERSION AS ChangeVersion, "
+                + $"T.{changeTrackingTableInfo.SortColumn} AS SortColumn "
+                + $"FROM  CHANGETABLE(CHANGES {changeTrackingTableInfo.GetFullTableName()} , {changeVersionFrom}) AS CT "
+                + $"INNER JOIN {changeTrackingTableInfo.GetFullTableName()} T "
+                + $"    ON T.{changeTrackingTableInfo.PrimaryKeyColumn} = CT.{changeTrackingTableInfo.PrimaryKeyColumn} "
+                + $"WHERE SYS_CHANGE_VERSION <= {changeVersionTo} ";
         }
     }
 }

--- a/Streams.ChangeTracking/Repository/Models/Change.cs
+++ b/Streams.ChangeTracking/Repository/Models/Change.cs
@@ -11,7 +11,7 @@ namespace Com.Rfranco.Streams.ChangeTracking.Models
     /// <summary>
     /// Change information
     /// </summary>
-    public class Change : IEquatable<Change>
+    public class Change : IEquatable<Change>, IComparable
     {
         public string PrimaryKeyValue { get; set; }
 
@@ -35,6 +35,8 @@ namespace Com.Rfranco.Streams.ChangeTracking.Models
 
         public long ChangeVersion { get; set; }
 
+        public dynamic SortColumn { get; set; }
+
         public bool Equals(Change other)
         {
             if (Object.ReferenceEquals(other, null)) return false;
@@ -50,6 +52,19 @@ namespace Com.Rfranco.Streams.ChangeTracking.Models
             int hashChangeOperation = _ChangeOperation.GetHashCode();
 
             return hashPrimaryKeyValue ^ hashChangeOperation;
+        }
+
+        public int CompareTo(object o)
+        {
+            var other = o as Change;
+            if(!SortColumn.GetType().Equals(other.SortColumn.GetType()))
+                throw new ArgumentException("The SortColumn of all tables should be of the same SQL type");
+
+            if(typeof(IComparable).IsAssignableFrom(SortColumn.GetType()))
+                return SortColumn.CompareTo(other.SortColumn);
+
+            throw new ArgumentException("The SortColumn type not implements the 'CompareTo' method. " + 
+                "An expecific comparer for this data type shold be implemented.");
         }
     }
 }

--- a/Streams.ChangeTracking/Repository/Models/TrackedTableInformation.cs
+++ b/Streams.ChangeTracking/Repository/Models/TrackedTableInformation.cs
@@ -10,6 +10,8 @@ namespace Com.Rfranco.Streams.ChangeTracking.Models
 
         public string PrimaryKeyColumn { get; set; }
 
+        public string SortColumn { get; set;}
+
         public int Priority { get; set; }
 
         public long MinValidVersion { get; set; }

--- a/Streams.ChangeTracking/Streams.ChangeTracking.csproj
+++ b/Streams.ChangeTracking/Streams.ChangeTracking.csproj
@@ -20,5 +20,6 @@
     <PackageReference Include="Dapper" Version="1.60.6" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="Com.RFranco.Streams" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>   
 </Project>


### PR DESCRIPTION
This feature allow to specified, via configuration, a sort criteria for the changes tracked on database. This sort is applicable for all tables if the change tracking is configure with multiple ones.